### PR TITLE
UI: Change global font to Lato

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" type="image/png" href="/src/assets/logo.png"/>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap" rel="stylesheet">
     <title>PromptPal - the prompt manager</title>
   </head>
   <body class="w-full h-full">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,10 @@ export default {
   ],
   darkMode: ['class', '[data-mantine-color-scheme="dark"]'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Lato', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', '"Noto Sans"', 'sans-serif'],
+      },
+    },
   },
 }


### PR DESCRIPTION
This PR changes the global font from browser default to Lato as requested in issue #62.

## Changes:
- Add Google Fonts integration with Lato font family
- Configure Tailwind CSS to use Lato as default sans font
- Include proper fallback fonts for cross-browser compatibility
- Add preconnect links for performance optimization

Resolves #62

Generated with [Claude Code](https://claude.ai/code)