### PR TITLE
fix: convert Link components to use proper TanStack Router syntax

### DIFF
--- a/src/components/Header/Header.modern.tsx
+++ b/src/components/Header/Header.modern.tsx
@@ -8,6 +8,7 @@ interface NavItemProps {
   icon: React.ReactNode
   label: string
   to: React.ComponentProps<typeof Link>['to']
+  params?: React.ComponentProps<typeof Link>['params']
   active?: boolean
 }
 
@@ -46,22 +47,26 @@ export function Header() {
               <nav className='hidden md:flex items-center gap-1 mr-4'>
                 <NavItem
                   icon={<Home size={18} strokeWidth={2} />}
-                  to={`/${pid}`}
+                  to='/$pid'
+                  params={{ pid }}
                   label='Dashboard'
                 />
                 <NavItem
                   icon={<PlusCircle size={18} strokeWidth={2} />}
-                  to={`/${pid}/prompts/new`}
+                  to='/$pid/prompts/new'
+                  params={{ pid }}
                   label='New Prompt'
                 />
                 <NavItem
                   icon={<Webhook size={18} strokeWidth={2} />}
-                  to={`/${pid}/webhooks`}
+                  to='/$pid/webhooks'
+                  params={{ pid }}
                   label='Webhooks'
                 />
                 <NavItem
                   icon={<Settings size={18} strokeWidth={2} />}
-                  to={`/${pid}/edit`}
+                  to='/$pid/edit'
+                  params={{ pid }}
                   label='Settings'
                 />
               </nav>
@@ -77,10 +82,11 @@ export function Header() {
   )
 }
 
-function NavItem({ icon, label, active, to }: NavItemProps) {
+function NavItem({ icon, label, active, to, params }: NavItemProps) {
   return (
     <Link
       to={to}
+      params={params}
       className={`
         relative flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium
         transition-all duration-200 group

--- a/src/pages/webhooks/components/EmptyState.tsx
+++ b/src/pages/webhooks/components/EmptyState.tsx
@@ -33,7 +33,8 @@ export function EmptyState() {
       {/* Action buttons */}
       <div className='flex flex-col sm:flex-row gap-4 pt-4'>
         <Link
-          to={`/${projectId}/webhooks/new`}
+          to='/$pid/webhooks/new'
+          params={{ pid: projectId.toString() }}
           className='inline-flex items-center gap-2 px-6 py-3 text-sm font-medium text-white bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700 rounded-lg shadow-md hover:shadow-lg transform hover:scale-105 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900'
         >
           <Plus className='h-4 w-4' />


### PR DESCRIPTION
Fixes #78

Converted Link components from hardcoded string paths to proper TanStack Router TypeScript-safe syntax.

## Changes
- Updated Header.modern.tsx NavItem components to use route params instead of template literals
- Fixed EmptyState.tsx Link to use proper routing syntax
- Added params prop support to NavItem interface

## Testing
- ESLint passed with no errors
- All changes follow existing TypeScript patterns

Generated with [Claude Code](https://claude.ai/code)