### PR TITLE
fix: refresh webhooks list after create/update mutations

### DIFF
--- a/src/pages/webhooks/webhook.create.tsx
+++ b/src/pages/webhooks/webhook.create.tsx
@@ -15,6 +15,7 @@ function CreateWebhookPage() {
   const projectId = ~~params.pid
 
   const [createWebhookMutation, { loading }] = useMutation(createWebhook, {
+    refetchQueries: ['allWebhooksList'],
     onCompleted: (data) => {
       if (data?.createWebhook.id) {
         navigate({ to: `/${projectId}/webhooks` })

--- a/src/pages/webhooks/webhook.edit.tsx
+++ b/src/pages/webhooks/webhook.edit.tsx
@@ -25,6 +25,7 @@ function EditWebhookPage() {
   })
 
   const [updateWebhookMutation, { loading }] = useMutation(updateWebhook, {
+    refetchQueries: ['allWebhooksList'],
     onCompleted: (data) => {
       const updatedWebhook = data?.updateWebhook.id
       if (!updatedWebhook) {


### PR DESCRIPTION
Add refetchQueries to createWebhook and updateWebhook mutations to ensure the Apollo store refreshes the webhooks list when mutations succeed.

Fixes #80

Generated with [Claude Code](https://claude.ai/code)